### PR TITLE
fix: correct DeviceActivity entity mapping from 'devices.activity' to…

### DIFF
--- a/Razorpay.csproj
+++ b/Razorpay.csproj
@@ -12,12 +12,12 @@
     <AssemblyCompany>Razorpay</AssemblyCompany>
     <AssemblyProduct>Razorpay .NET SDK</AssemblyProduct>
     <AssemblyCopyright>Copyright © Razorpay 2015-2025</AssemblyCopyright>
-    <AssemblyVersion>3.3.1.0</AssemblyVersion>
-    <FileVersion>3.3.1.0</FileVersion>
+    <AssemblyVersion>3.3.2.0</AssemblyVersion>
+    <FileVersion>3.3.2.0</FileVersion>
     
     <!-- Package Information -->
     <PackageId>Razorpay</PackageId>
-    <PackageVersion>3.3.1</PackageVersion>
+    <PackageVersion>3.3.2</PackageVersion>
     <Authors>razorpay</Authors>
     <Owners>razorpay</Owners>
     <Description>Razorpay SDK for .NET - Official payment processing library</Description>

--- a/src/Entity.cs
+++ b/src/Entity.cs
@@ -43,7 +43,7 @@ namespace Razorpay.Api
             {"methods","Razorpay.Api.Method"},
             {"dispute", "Razorpay.Api.Dispute"},
             {"bank_account", "Razorpay.Api.BankAccount"},
-            {"devices.activity", "Razorpay.Api.DeviceActivity"},
+            {"device.activity", "Razorpay.Api.DeviceActivity"},
         };
       
         private static List<HttpMethod> JsonifyInput = new List<HttpMethod>()

--- a/src/RazorpayClient.cs
+++ b/src/RazorpayClient.cs
@@ -5,7 +5,7 @@ namespace Razorpay.Api
 {
     public class RazorpayClient
     {
-        const string CurrentVersion = "3.3.1";
+        const string CurrentVersion = "3.3.2";
         protected const string DefaultBaseUrl = "https://api.razorpay.com";
         public const string DefaultAuthUrl = "https://auth.razorpay.com";
 


### PR DESCRIPTION
… 'device.activity'

- Fix entity mapping to match actual API response format
- API returns 'device.activity' (singular) not 'devices.activity' (plural)
- This resolves casting issues where DeviceActivity API responses were falling back to generic Entity objects
- Restores functionality that was accidentally broken in commit a8f16ae

Fixes type casting errors when using client.DeviceActivity.Create() and client.DeviceActivity.GetStatus()

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
