### PR TITLE
chore: upgrade to .NET 8/9/10 LTS, update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Verify all target frameworks
       run: |
         Write-Host "Verifying .NET Framework builds on native Windows..."
-        $frameworks = @("net48", "netstandard2.0", "net8.0", "net9.0", "net10.0")
+        $frameworks = @("net47", "net48", "netstandard2.0", "net8.0", "net9.0", "net10.0")
         $allBuilt = $true
 
         foreach ($fw in $frameworks) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,9 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
+          9.0.x
+          10.0.x
         
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
@@ -37,9 +38,9 @@ jobs:
     - name: Verify all target frameworks
       run: |
         Write-Host "Verifying .NET Framework builds on native Windows..."
-        $frameworks = @("net47", "net48", "netstandard2.0", "net6.0", "net8.0")
+        $frameworks = @("net48", "netstandard2.0", "net8.0", "net9.0", "net10.0")
         $allBuilt = $true
-        
+
         foreach ($fw in $frameworks) {
           $dllPath = "bin/Release/$fw/Razorpay.dll"
           if (Test-Path $dllPath) {
@@ -50,7 +51,7 @@ jobs:
             $allBuilt = $false
           }
         }
-        
+
         if (-not $allBuilt) {
           Write-Host "❌ Some frameworks failed to build!" -ForegroundColor Red
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 *.suo
 *.user
 .vs
-bin
-packages
-TestResults
+bin/
+obj/
+packages/
+TestResults/
 /net40/obj
 /net45/obj
 /net40/bin
@@ -17,3 +18,7 @@ TestResults
 
 # Rider files
 .idea/
+
+# NuGet packages
+*.nupkg
+*.snupkg

--- a/Razorpay.csproj
+++ b/Razorpay.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Multi-targeting: Support multiple .NET versions -->
     <!-- net6.0 removed (EOL Nov 2024), added net9.0 and net10.0 -->
-    <TargetFrameworks>net48;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net47;net48;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     
     <!-- Assembly Information -->
     <RootNamespace>Razorpay.Api</RootNamespace>
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <!-- Framework-specific dependencies -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47' OR '$(TargetFramework)' == 'net48'">
     <!-- .NET Framework specific packages -->
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
@@ -70,6 +70,11 @@
   <!-- Modern .NET specific dependencies -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
     <!-- Modern .NET specific packages if needed -->
+  </ItemGroup>
+
+  <!-- .NET Framework 4.7 specific dependencies -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <!-- net47 maintained for backward compatibility with enterprise users -->
   </ItemGroup>
 
 </Project>

--- a/Razorpay.csproj
+++ b/Razorpay.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!-- Multi-targeting: Support multiple .NET versions -->
-    <TargetFrameworks>net47;net48;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <!-- net6.0 removed (EOL Nov 2024), added net9.0 and net10.0 -->
+    <TargetFrameworks>net48;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     
     <!-- Assembly Information -->
     <RootNamespace>Razorpay.Api</RootNamespace>
@@ -25,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/razorpay/razorpay-dot-net/blob/master/licence.txt</PackageLicenseUrl>
     <PackageIconUrl>https://razorpay.com/favicon.png</PackageIconUrl>
     <PackageTags>Razorpay;Payment;Gateway;API;SDK</PackageTags>
-    <PackageReleaseNotes>Added .NET Standard 2.0 support for maximum compatibility across .NET ecosystem. Supports .NET Framework 4.7+, .NET Core 2.0+, .NET 5+, and modern .NET 6.0+</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to support .NET 8.0, 9.0, and 10.0 LTS. Dropped EOL .NET 6.0. Maintains backward compatibility with .NET Framework 4.8 and .NET Standard 2.0.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     
     <!-- Build Configuration -->
@@ -49,12 +50,12 @@
 
   <!-- Package Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 
   <!-- Framework-specific dependencies -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47' OR '$(TargetFramework)' == 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <!-- .NET Framework specific packages -->
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
@@ -67,7 +68,7 @@
   </ItemGroup>
 
   <!-- Modern .NET specific dependencies -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'">
     <!-- Modern .NET specific packages if needed -->
   </ItemGroup>
 


### PR DESCRIPTION
- Drop EOL .NET 6.0 (ended Nov 2024)
- Add .NET 9.0 and .NET 10.0 LTS support
- Keep net48 and netstandard2.0 for backward compatibility
- Update Newtonsoft.Json 13.0.3 → 13.0.4
- Update CI to build/test against .NET 8/9/10
- Update .gitignore for modern SDK-style project

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
